### PR TITLE
require node 16 due to adapter-core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/ThomasPohl/ioBroker.google-spreadsheet.git"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 16"
   },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.3",


### PR DESCRIPTION
adapter-core 3.x.x. is known to fail when installing at node 14 due to npm 6 not installing peerDependencies. So this adapter requires node 16 or newer.

Please consider releasing a new version to enforce this as soon as it seems to be appropiate for you.