### PR TITLE
Update test-and-release.yml - add --engine-strict option

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       # - uses: ioBroker/testing-action-adapter@v1
-      - uses: mcm1957/testing-action-adapter@d7b600e2138e3227dfe7f613dab14c4d0209d004
+      - uses: mcm1957/testing-action-adapter@4fce35411be87430bb11e094627d29f370ef4798
         with:
           node-version: ${{ matrix.node-version }}
           os: ${{ matrix.os }}

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       # - uses: ioBroker/testing-action-adapter@v1
-      - uses: mcm1957/testing-action-adapter@db3ed63cdb31e108983e8c75adc3148e5d890395
+      - uses: mcm1957/testing-action-adapter@d7b600e2138e3227dfe7f613dab14c4d0209d004
         with:
           node-version: ${{ matrix.node-version }}
           os: ${{ matrix.os }}

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -51,7 +51,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           os: ${{ matrix.os }}
           # Uncomment the following line if your adapter cannot be installed using 'npm ci'
-          install-command: 'npm install --engine-strict'
+          install-command: 'npm install'
           engine-strict: false
           build: true
 

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -50,7 +50,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           os: ${{ matrix.os }}
           # Uncomment the following line if your adapter cannot be installed using 'npm ci'
-          install-command: 'npm install'
+          install-command: 'npm install --engine-strict'
           build: true
 
 # TODO: To enable automatic npm releases, create a token on npmjs.org 

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -52,6 +52,7 @@ jobs:
           os: ${{ matrix.os }}
           # Uncomment the following line if your adapter cannot be installed using 'npm ci'
           install-command: 'npm install --engine-strict'
+          engine-strict: false
           build: true
 
 # TODO: To enable automatic npm releases, create a token on npmjs.org 

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -45,7 +45,8 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-      - uses: ioBroker/testing-action-adapter@v1
+      # - uses: ioBroker/testing-action-adapter@v1
+      - uses: mcm1957/testing-action-adapter@3a3265beda06eeda685b068bdcd3a12f48ee167b
         with:
           node-version: ${{ matrix.node-version }}
           os: ${{ matrix.os }}

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       # - uses: ioBroker/testing-action-adapter@v1
-      - uses: mcm1957/testing-action-adapter@3a3265beda06eeda685b068bdcd3a12f48ee167b
+      - uses: mcm1957/testing-action-adapter@db3ed63cdb31e108983e8c75adc3148e5d890395
         with:
           node-version: ${{ matrix.node-version }}
           os: ${{ matrix.os }}

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -52,7 +52,6 @@ jobs:
           os: ${{ matrix.os }}
           # Uncomment the following line if your adapter cannot be installed using 'npm ci'
           install-command: 'npm install'
-          engine-strict: false
           build: true
 
 # TODO: To enable automatic npm releases, create a token on npmjs.org 


### PR DESCRIPTION
This PR adds --engine-strict to the npm install command used at test-and.release.yml.

**NOTE: This change will let tests at node.js18 fail** - which is correct as some dependencies do not support node.js any longer.